### PR TITLE
Adding malwaredomainlist_enabled key

### DIFF
--- a/config.py.editme
+++ b/config.py.editme
@@ -60,6 +60,11 @@ malekal_files_path = ""
 malwaredomains_enabled = False
 
 ################################################################
+# Malwaredomainlist - domains
+################################################################
+malwaredomainlist_enabled = False
+
+################################################################
 # Malwareteks - domains
 ################################################################
 # Too many trackers, useless for malware IOC


### PR DESCRIPTION
Hi guys,

Just a little key missing in the config file for the malwaredomainlist module.
Thank you for sharing your work on IoC research.

Regards,

Cheyen